### PR TITLE
Replaced sync methods with corresponding async versions

### DIFF
--- a/src/SharpGIS.HttpClient.WP/Http/HttpContent.cs
+++ b/src/SharpGIS.HttpClient.WP/Http/HttpContent.cs
@@ -105,7 +105,7 @@ namespace System.Net.Http
 				byte[] buffer = new byte[1024];
 				while ((count = await stream.ReadAsync(buffer, 0, 1024)) > 0)
 				{
-					ms.Write(buffer, 0, count);
+					await ms.WriteAsync(buffer, 0, count);
 				}
 				return ms.ToArray();
 			}


### PR DESCRIPTION
I am Semih Okur, a PhD student in the CS department at the University of Illinois. I'm currently doing research on asynchronous programming in phone applications. I found many misuses of async/await keywords in Windows Phone applications. One typical misuse is that developers use synchronous method calls in async methods. However, these synchronous method calls have corresponding asynchronous versions in .NET API.

I found some opportunities in your application and created a pull request for the patch
